### PR TITLE
[CLEANUP] Drop the dependency of roave/security-advisories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Deprecated
 
 ### Removed
+- Drop the dependency of roave/security-advisories (#41)
 
 ### Fixed
 - Explicitly require MySQL on Travis CI (#38)

--- a/composer.json
+++ b/composer.json
@@ -36,8 +36,7 @@
         "helhum/typo3-composer-setup": "^0.5.3",
         "helmich/typo3-typoscript-lint": "^1.4.7",
         "nimut/testing-framework": "^4.1.3",
-        "codeception/codeception": "^2.5",
-        "roave/security-advisories": "dev-master"
+        "codeception/codeception": "^2.5"
     },
     "replace": {
         "tea": "self.version",


### PR DESCRIPTION
This dependency should be on the site project or the distribution, not
on the individual extensions.