### PR TITLE
[TASK] Stop building with the lowest Composer dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
 
 install:
 - >
-  composer require typo3/minimal:"$TYPO3" $DEPENDENCIES_PREFERENCE;
+  composer require typo3/minimal:"$TYPO3";
   composer show;
 - >
   echo;
@@ -58,14 +58,8 @@ jobs:
     php: "7.3"
     env: TYPO3=^9.5
   - stage: test
-    php: "7.3"
-    env: TYPO3=^9.5 DEPENDENCIES_PREFERENCE="--prefer-lowest"
-  - stage: test
     php: "7.2"
     env: TYPO3=^9.5
-  - stage: test
-    php: "7.2"
-    env: TYPO3=^9.5 DEPENDENCIES_PREFERENCE="--prefer-lowest"
   - stage: release to ter
     if: tag IS present AND env(TYPO3_ORG_USERNAME) IS present AND env(TYPO3_ORG_PASSWORD) IS present
     php: "7.2"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Deprecated
 
 ### Removed
+- Stop building with the lowest Composer dependencies (#55)
 - Drop support for TYPO3 < 9.5 (#50)
 - Drop support for PHP < 7.2 (#49)
 - Drop support for TYPO3 7.6 and require TYPO3 >= 8.7 (#47)

--- a/composer.json
+++ b/composer.json
@@ -43,9 +43,6 @@
     "replace": {
         "typo3-ter/tea": "self.version"
     },
-    "conflict": {
-        "typo3/cms-composer-installers": "<1.4.6"
-    },
     "autoload": {
         "psr-4": {
             "OliverKlee\\Tea\\": "Classes/"


### PR DESCRIPTION
This has been too much of a hassle due to breakage caused by old
dev dependencies.